### PR TITLE
make the FolderOnlyDocumentListFilter#filter compatible for versions 15.7.1+ and 16.2.0+

### DIFF
--- a/frontend/src/main/java/org/onehippo/forge/folderctxmenus/cms/plugin/FolderOnlyDocumentListFilter.java
+++ b/frontend/src/main/java/org/onehippo/forge/folderctxmenus/cms/plugin/FolderOnlyDocumentListFilter.java
@@ -34,6 +34,10 @@ public class FolderOnlyDocumentListFilter extends DocumentListFilter {
 
     @Override
     public NodeIterator filter(Node current, final NodeIterator iter) {
+        return filter(iter);
+    }
+
+    public NodeIterator filter(final NodeIterator iter) {
         return new NodeIterator() {
             private int index = 0;
             private Node nextNode;


### PR DESCRIPTION
As of version 15.7.1 and 16.2.0, documents are also displayed in the CopyOrMoveFolderDialogue because the executed filter method is no longer overwritten