### PR TITLE
chore: FORGE-600 upgrade Folder Context Menus to BrXM v17

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -1,5 +1,5 @@
 Extra Folder Context Menus
-Copyright 2024 Bloomreach (https://www.bloomreach.com)
+Copyright 2026 Bloomreach (https://www.bloomreach.com)
 
 This product includes software developed by:
 Bloomreach Inc (https://www.bloomreach.com/);

--- a/common/pom.xml
+++ b/common/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  Copyright 2024 Bloomreach (https://www.bloomreach.com)
+  Copyright 2026 Bloomreach (https://www.bloomreach.com)
 
   Licensed under the Apache License, Version 2.0
   (the "License"); you may not use this file except in compliance with the

--- a/common/pom.xml
+++ b/common/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>org.onehippo.forge.folderctxmenus</groupId>
         <artifactId>folderctxmenus</artifactId>
-        <version>7.2.0-SNAPSHOT</version>
+        <version>8.0.0-SNAPSHOT</version>
     </parent>
 
     <name>Bloomreach XM Extra Folder Context Menus Common</name>

--- a/common/src/main/java/org/onehippo/forge/folderctxmenus/common/AbstractFolderCopyOrMoveTask.java
+++ b/common/src/main/java/org/onehippo/forge/folderctxmenus/common/AbstractFolderCopyOrMoveTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Bloomreach (https://www.bloomreach.com)
+ * Copyright 2026 Bloomreach (https://www.bloomreach.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/common/src/main/java/org/onehippo/forge/folderctxmenus/common/AbstractFolderTask.java
+++ b/common/src/main/java/org/onehippo/forge/folderctxmenus/common/AbstractFolderTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Bloomreach (https://www.bloomreach.com)
+ * Copyright 2026 Bloomreach (https://www.bloomreach.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/common/src/main/java/org/onehippo/forge/folderctxmenus/common/ExtendedFolderWorkflow.java
+++ b/common/src/main/java/org/onehippo/forge/folderctxmenus/common/ExtendedFolderWorkflow.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Bloomreach (https://www.bloomreach.com)
+ * Copyright 2026 Bloomreach (https://www.bloomreach.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/common/src/main/java/org/onehippo/forge/folderctxmenus/common/ExtendedFolderWorkflowImpl.java
+++ b/common/src/main/java/org/onehippo/forge/folderctxmenus/common/ExtendedFolderWorkflowImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Bloomreach (https://www.bloomreach.com)
+ * Copyright 2026 Bloomreach (https://www.bloomreach.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/common/src/main/java/org/onehippo/forge/folderctxmenus/common/FolderCopyTask.java
+++ b/common/src/main/java/org/onehippo/forge/folderctxmenus/common/FolderCopyTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Bloomreach (https://www.bloomreach.com)
+ * Copyright 2026 Bloomreach (https://www.bloomreach.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/common/src/main/java/org/onehippo/forge/folderctxmenus/common/FolderMoveTask.java
+++ b/common/src/main/java/org/onehippo/forge/folderctxmenus/common/FolderMoveTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Bloomreach (https://www.bloomreach.com)
+ * Copyright 2026 Bloomreach (https://www.bloomreach.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/common/src/main/java/org/onehippo/forge/folderctxmenus/common/JcrCopyUtils.java
+++ b/common/src/main/java/org/onehippo/forge/folderctxmenus/common/JcrCopyUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Bloomreach (https://www.bloomreach.com)
+ * Copyright 2026 Bloomreach (https://www.bloomreach.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/common/src/main/java/org/onehippo/forge/folderctxmenus/common/JcrTraverseUtils.java
+++ b/common/src/main/java/org/onehippo/forge/folderctxmenus/common/JcrTraverseUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Bloomreach (https://www.bloomreach.com)
+ * Copyright 2026 Bloomreach (https://www.bloomreach.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/common/src/main/java/org/onehippo/forge/folderctxmenus/common/NodeCounter.java
+++ b/common/src/main/java/org/onehippo/forge/folderctxmenus/common/NodeCounter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Bloomreach (https://www.bloomreach.com)
+ * Copyright 2026 Bloomreach (https://www.bloomreach.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/common/src/main/java/org/onehippo/forge/folderctxmenus/common/NodeTraverser.java
+++ b/common/src/main/java/org/onehippo/forge/folderctxmenus/common/NodeTraverser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Bloomreach (https://www.bloomreach.com)
+ * Copyright 2026 Bloomreach (https://www.bloomreach.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/common/src/main/java/org/onehippo/forge/folderctxmenus/common/OperationCancelledException.java
+++ b/common/src/main/java/org/onehippo/forge/folderctxmenus/common/OperationCancelledException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Bloomreach (https://www.bloomreach.com)
+ * Copyright 2026 Bloomreach (https://www.bloomreach.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/common/src/main/java/org/onehippo/forge/folderctxmenus/common/OperationProgress.java
+++ b/common/src/main/java/org/onehippo/forge/folderctxmenus/common/OperationProgress.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Bloomreach (https://www.bloomreach.com)
+ * Copyright 2026 Bloomreach (https://www.bloomreach.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/common/src/main/java/org/onehippo/forge/folderctxmenus/common/ProgressTrackingCopyHandler.java
+++ b/common/src/main/java/org/onehippo/forge/folderctxmenus/common/ProgressTrackingCopyHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Bloomreach (https://www.bloomreach.com)
+ * Copyright 2026 Bloomreach (https://www.bloomreach.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/common/src/main/java/org/onehippo/forge/folderctxmenus/common/UUIDUtils.java
+++ b/common/src/main/java/org/onehippo/forge/folderctxmenus/common/UUIDUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Bloomreach (https://www.bloomreach.com)
+ * Copyright 2026 Bloomreach (https://www.bloomreach.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/common/src/test/java/org/onehippo/forge/folderctxmenus/common/AbstractFolderTaskTest.java
+++ b/common/src/test/java/org/onehippo/forge/folderctxmenus/common/AbstractFolderTaskTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Bloomreach (https://www.bloomreach.com)
+ * Copyright 2026 Bloomreach (https://www.bloomreach.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/common/src/test/java/org/onehippo/forge/folderctxmenus/common/FolderOperationProgressIntegrationTest.java
+++ b/common/src/test/java/org/onehippo/forge/folderctxmenus/common/FolderOperationProgressIntegrationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Bloomreach (https://www.bloomreach.com)
+ * Copyright 2026 Bloomreach (https://www.bloomreach.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/common/src/test/java/org/onehippo/forge/folderctxmenus/common/JcrCopyUtilsTest.java
+++ b/common/src/test/java/org/onehippo/forge/folderctxmenus/common/JcrCopyUtilsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Bloomreach (https://www.bloomreach.com)
+ * Copyright 2026 Bloomreach (https://www.bloomreach.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/common/src/test/java/org/onehippo/forge/folderctxmenus/common/JcrTraverseUtilsTest.java
+++ b/common/src/test/java/org/onehippo/forge/folderctxmenus/common/JcrTraverseUtilsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Bloomreach (https://www.bloomreach.com)
+ * Copyright 2026 Bloomreach (https://www.bloomreach.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/common/src/test/java/org/onehippo/forge/folderctxmenus/common/NodeCounterTest.java
+++ b/common/src/test/java/org/onehippo/forge/folderctxmenus/common/NodeCounterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Bloomreach (https://www.bloomreach.com)
+ * Copyright 2026 Bloomreach (https://www.bloomreach.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/common/src/test/java/org/onehippo/forge/folderctxmenus/common/NodeTraverserTest.java
+++ b/common/src/test/java/org/onehippo/forge/folderctxmenus/common/NodeTraverserTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Bloomreach (https://www.bloomreach.com)
+ * Copyright 2026 Bloomreach (https://www.bloomreach.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/common/src/test/java/org/onehippo/forge/folderctxmenus/common/OperationCancelledExceptionTest.java
+++ b/common/src/test/java/org/onehippo/forge/folderctxmenus/common/OperationCancelledExceptionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Bloomreach (https://www.bloomreach.com)
+ * Copyright 2026 Bloomreach (https://www.bloomreach.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/common/src/test/java/org/onehippo/forge/folderctxmenus/common/OperationProgressTest.java
+++ b/common/src/test/java/org/onehippo/forge/folderctxmenus/common/OperationProgressTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Bloomreach (https://www.bloomreach.com)
+ * Copyright 2026 Bloomreach (https://www.bloomreach.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/common/src/test/java/org/onehippo/forge/folderctxmenus/common/ProgressTrackingCopyHandlerTest.java
+++ b/common/src/test/java/org/onehippo/forge/folderctxmenus/common/ProgressTrackingCopyHandlerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Bloomreach (https://www.bloomreach.com)
+ * Copyright 2026 Bloomreach (https://www.bloomreach.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/common/src/test/java/org/onehippo/forge/folderctxmenus/common/UUIDUtilsTest.java
+++ b/common/src/test/java/org/onehippo/forge/folderctxmenus/common/UUIDUtilsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Bloomreach (https://www.bloomreach.com)
+ * Copyright 2026 Bloomreach (https://www.bloomreach.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/demo/cms-dependencies/pom.xml
+++ b/demo/cms-dependencies/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.onehippo.forge.folderctxmenus</groupId>
     <artifactId>folderctxmenus-demo</artifactId>
-    <version>7.2.0-SNAPSHOT</version>
+    <version>8.0.0-SNAPSHOT</version>
   </parent>
   <artifactId>folderctxmenus-demo-cms-dependencies</artifactId>
   <packaging>pom</packaging>

--- a/demo/cms/pom.xml
+++ b/demo/cms/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.onehippo.forge.folderctxmenus</groupId>
     <artifactId>folderctxmenus-demo</artifactId>
-    <version>7.2.0-SNAPSHOT</version>
+    <version>8.0.0-SNAPSHOT</version>
   </parent>
   <artifactId>folderctxmenus-demo-cms</artifactId>
   <packaging>war</packaging>

--- a/demo/essentials/pom.xml
+++ b/demo/essentials/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.onehippo.forge.folderctxmenus</groupId>
     <artifactId>folderctxmenus-demo</artifactId>
-    <version>7.2.0-SNAPSHOT</version>
+    <version>8.0.0-SNAPSHOT</version>
   </parent>
   <artifactId>folderctxmenus-demo-essentials</artifactId>
   <packaging>war</packaging>

--- a/demo/pom.xml
+++ b/demo/pom.xml
@@ -5,14 +5,14 @@
   <parent>
     <groupId>org.onehippo.cms7</groupId>
     <artifactId>hippo-cms7-release</artifactId>
-    <version>16.6.5</version>
+    <version>17.0.0</version>
   </parent>
 
   <name>Bloomreach XM Extra Folder Context Menus Demo</name>
   <description>Bloomreach XM Extra Folder Context Menus Demo</description>
   <groupId>org.onehippo.forge.folderctxmenus</groupId>
   <artifactId>folderctxmenus-demo</artifactId>
-  <version>7.2.0-SNAPSHOT</version>
+  <version>8.0.0-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <!--

--- a/demo/repository-data/application/pom.xml
+++ b/demo/repository-data/application/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.onehippo.forge.folderctxmenus</groupId>
     <artifactId>folderctxmenus-demo-repository-data</artifactId>
-    <version>7.2.0-SNAPSHOT</version>
+    <version>8.0.0-SNAPSHOT</version>
   </parent>
 
   <name>Bloomreach XM Extra Folder Context Menus Demo Repository Data For Application</name>

--- a/demo/repository-data/development/pom.xml
+++ b/demo/repository-data/development/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.onehippo.forge.folderctxmenus</groupId>
     <artifactId>folderctxmenus-demo-repository-data</artifactId>
-    <version>7.2.0-SNAPSHOT</version>
+    <version>8.0.0-SNAPSHOT</version>
   </parent>
 
   <name>Bloomreach XM Extra Folder Context Menus Demo Repository Data For Development</name>

--- a/demo/repository-data/pom.xml
+++ b/demo/repository-data/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.onehippo.forge.folderctxmenus</groupId>
     <artifactId>folderctxmenus-demo</artifactId>
-    <version>7.2.0-SNAPSHOT</version>
+    <version>8.0.0-SNAPSHOT</version>
   </parent>
 
   <name>Bloomreach XM Extra Folder Context Menus Demo Repository Data</name>

--- a/demo/repository-data/site/pom.xml
+++ b/demo/repository-data/site/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.onehippo.forge.folderctxmenus</groupId>
     <artifactId>folderctxmenus-demo-repository-data</artifactId>
-    <version>7.2.0-SNAPSHOT</version>
+    <version>8.0.0-SNAPSHOT</version>
   </parent>
 
   <name>Bloomreach XM Extra Folder Context Menus Demo Repository Data For Site</name>

--- a/demo/repository-data/webfiles/pom.xml
+++ b/demo/repository-data/webfiles/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.onehippo.forge.folderctxmenus</groupId>
     <artifactId>folderctxmenus-demo-repository-data</artifactId>
-    <version>7.2.0-SNAPSHOT</version>
+    <version>8.0.0-SNAPSHOT</version>
   </parent>
 
   <name>Bloomreach XM Extra Folder Context Menus Demo Repository Data Web Files</name>

--- a/demo/site/components/pom.xml
+++ b/demo/site/components/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.onehippo.forge.folderctxmenus</groupId>
     <artifactId>folderctxmenus-demo-site</artifactId>
-    <version>7.2.0-SNAPSHOT</version>
+    <version>8.0.0-SNAPSHOT</version>
   </parent>
   <artifactId>folderctxmenus-demo-components</artifactId>
   <packaging>jar</packaging>

--- a/demo/site/components/src/main/java/org/onehippo/forge/folderctxmenus/demo/beans/EventsDocument.java
+++ b/demo/site/components/src/main/java/org/onehippo/forge/folderctxmenus/demo/beans/EventsDocument.java
@@ -1,6 +1,6 @@
 package org.onehippo.forge.folderctxmenus.demo.beans;
 /*
- * Copyright 2024 Bloomreach (http://www.bloomreach.com)
+ * Copyright 2026 Bloomreach (http://www.bloomreach.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/demo/site/components/src/main/java/org/onehippo/forge/folderctxmenus/demo/beans/NewsDocument.java
+++ b/demo/site/components/src/main/java/org/onehippo/forge/folderctxmenus/demo/beans/NewsDocument.java
@@ -1,6 +1,6 @@
 package org.onehippo.forge.folderctxmenus.demo.beans;
 /*
- * Copyright 2024 Bloomreach (http://www.bloomreach.com)
+ * Copyright 2026 Bloomreach (http://www.bloomreach.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/demo/site/pom.xml
+++ b/demo/site/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.onehippo.forge.folderctxmenus</groupId>
     <artifactId>folderctxmenus-demo</artifactId>
-    <version>7.2.0-SNAPSHOT</version>
+    <version>8.0.0-SNAPSHOT</version>
   </parent>
   <artifactId>folderctxmenus-demo-site</artifactId>
   <packaging>pom</packaging>

--- a/demo/site/webapp/pom.xml
+++ b/demo/site/webapp/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.onehippo.forge.folderctxmenus</groupId>
     <artifactId>folderctxmenus-demo-site</artifactId>
-    <version>7.2.0-SNAPSHOT</version>
+    <version>8.0.0-SNAPSHOT</version>
   </parent>
   <artifactId>folderctxmenus-demo-webapp</artifactId>
   <packaging>war</packaging>
@@ -26,7 +26,7 @@
     <dependency>
       <groupId>org.onehippo.forge.folderctxmenus</groupId>
       <artifactId>folderctxmenus-demo-components</artifactId>
-      <version>7.2.0-SNAPSHOT</version>
+      <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>org.onehippo.cms7.hst.toolkit-resources.addon</groupId>

--- a/frontend/pom.xml
+++ b/frontend/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  Copyright 2024 Bloomreach (https://www.bloomreach.com)
+  Copyright 2026 Bloomreach (https://www.bloomreach.com)
 
   Licensed under the Apache License, Version 2.0
   (the "License"); you may not use this file except in compliance with the

--- a/frontend/pom.xml
+++ b/frontend/pom.xml
@@ -16,7 +16,7 @@
   <parent>
     <groupId>org.onehippo.forge.folderctxmenus</groupId>
     <artifactId>folderctxmenus</artifactId>
-    <version>7.2.0-SNAPSHOT</version>
+    <version>8.0.0-SNAPSHOT</version>
   </parent>
 
   <name>Bloomreach XM Extra Folder Context Menus Frontend</name>
@@ -98,14 +98,14 @@
     </dependency>
 
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
       <scope>test</scope>
     </dependency>
 
     <dependency>
-      <groupId>org.junit.vintage</groupId>
-      <artifactId>junit-vintage-engine</artifactId>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
       <scope>test</scope>
     </dependency>
 

--- a/frontend/src/main/java/org/onehippo/forge/folderctxmenus/cms/plugin/AbstractFolderActionWorkflowMenuItemPlugin.java
+++ b/frontend/src/main/java/org/onehippo/forge/folderctxmenus/cms/plugin/AbstractFolderActionWorkflowMenuItemPlugin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Bloomreach (https://www.bloomreach.com)
+ * Copyright 2026 Bloomreach (https://www.bloomreach.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/frontend/src/main/java/org/onehippo/forge/folderctxmenus/cms/plugin/AbstractFolderDialog.java
+++ b/frontend/src/main/java/org/onehippo/forge/folderctxmenus/cms/plugin/AbstractFolderDialog.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Bloomreach (https://www.bloomreach.com)
+ * Copyright 2026 Bloomreach (https://www.bloomreach.com)
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/frontend/src/main/java/org/onehippo/forge/folderctxmenus/cms/plugin/CopyFolderWorkflowMenuItemPlugin.java
+++ b/frontend/src/main/java/org/onehippo/forge/folderctxmenus/cms/plugin/CopyFolderWorkflowMenuItemPlugin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Bloomreach (https://www.bloomreach.com)
+ * Copyright 2026 Bloomreach (https://www.bloomreach.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/frontend/src/main/java/org/onehippo/forge/folderctxmenus/cms/plugin/CopyOrMoveFolderDialog.java
+++ b/frontend/src/main/java/org/onehippo/forge/folderctxmenus/cms/plugin/CopyOrMoveFolderDialog.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Bloomreach (https://www.bloomreach.com)
+ * Copyright 2026 Bloomreach (https://www.bloomreach.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/frontend/src/main/java/org/onehippo/forge/folderctxmenus/cms/plugin/FolderActionDocumentArguments.java
+++ b/frontend/src/main/java/org/onehippo/forge/folderctxmenus/cms/plugin/FolderActionDocumentArguments.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Bloomreach (https://www.bloomreach.com)
+ * Copyright 2026 Bloomreach (https://www.bloomreach.com)
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/frontend/src/main/java/org/onehippo/forge/folderctxmenus/cms/plugin/FolderOnlyDocumentListFilter.java
+++ b/frontend/src/main/java/org/onehippo/forge/folderctxmenus/cms/plugin/FolderOnlyDocumentListFilter.java
@@ -33,10 +33,6 @@ public class FolderOnlyDocumentListFilter extends DocumentListFilter {
     }
 
     @Override
-    public NodeIterator filter(Node current, final NodeIterator iter) {
-        return filter(iter);
-    }
-
     public NodeIterator filter(final NodeIterator iter) {
         return new NodeIterator() {
             private int index = 0;

--- a/frontend/src/main/java/org/onehippo/forge/folderctxmenus/cms/plugin/FolderOnlyDocumentListFilter.java
+++ b/frontend/src/main/java/org/onehippo/forge/folderctxmenus/cms/plugin/FolderOnlyDocumentListFilter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Bloomreach (https://www.bloomreach.com)
+ * Copyright 2026 Bloomreach (https://www.bloomreach.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/frontend/src/main/java/org/onehippo/forge/folderctxmenus/cms/plugin/FolderSelectionCmsJcrTree.java
+++ b/frontend/src/main/java/org/onehippo/forge/folderctxmenus/cms/plugin/FolderSelectionCmsJcrTree.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Bloomreach (https://www.bloomreach.com)
+ * Copyright 2026 Bloomreach (https://www.bloomreach.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/frontend/src/main/java/org/onehippo/forge/folderctxmenus/cms/plugin/ITreeNodeEventListener.java
+++ b/frontend/src/main/java/org/onehippo/forge/folderctxmenus/cms/plugin/ITreeNodeEventListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Bloomreach (https://www.bloomreach.com)
+ * Copyright 2026 Bloomreach (https://www.bloomreach.com)
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/frontend/src/main/java/org/onehippo/forge/folderctxmenus/cms/plugin/MoveFolderWorkflowMenuItemPlugin.java
+++ b/frontend/src/main/java/org/onehippo/forge/folderctxmenus/cms/plugin/MoveFolderWorkflowMenuItemPlugin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Bloomreach (https://www.bloomreach.com)
+ * Copyright 2026 Bloomreach (https://www.bloomreach.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/frontend/src/main/java/org/onehippo/forge/folderctxmenus/cms/plugin/ProgressCompletionSummary.java
+++ b/frontend/src/main/java/org/onehippo/forge/folderctxmenus/cms/plugin/ProgressCompletionSummary.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Bloomreach (https://www.bloomreach.com)
+ * Copyright 2026 Bloomreach (https://www.bloomreach.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/frontend/src/main/java/org/onehippo/forge/folderctxmenus/cms/plugin/ProgressPanel.java
+++ b/frontend/src/main/java/org/onehippo/forge/folderctxmenus/cms/plugin/ProgressPanel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Bloomreach (https://www.bloomreach.com)
+ * Copyright 2026 Bloomreach (https://www.bloomreach.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/frontend/src/main/java/org/onehippo/forge/folderctxmenus/cms/plugin/ProgressPanelJsonBuilder.java
+++ b/frontend/src/main/java/org/onehippo/forge/folderctxmenus/cms/plugin/ProgressPanelJsonBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Bloomreach (https://www.bloomreach.com)
+ * Copyright 2026 Bloomreach (https://www.bloomreach.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/frontend/src/main/java/org/onehippo/forge/folderctxmenus/cms/plugin/ProgressTrackingOperationProgress.java
+++ b/frontend/src/main/java/org/onehippo/forge/folderctxmenus/cms/plugin/ProgressTrackingOperationProgress.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Bloomreach (https://www.bloomreach.com)
+ * Copyright 2026 Bloomreach (https://www.bloomreach.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/frontend/src/main/resources/org/onehippo/forge/folderctxmenus/cms/plugin/AbstractFolderActionWorkflowMenuItemPlugin.html
+++ b/frontend/src/main/resources/org/onehippo/forge/folderctxmenus/cms/plugin/AbstractFolderActionWorkflowMenuItemPlugin.html
@@ -1,5 +1,5 @@
 <!--
-  Copyright 2024 Bloomreach (https://www.bloomreach.com)
+  Copyright 2026 Bloomreach (https://www.bloomreach.com)
 
   Licensed under the Apache License, Version 2.0
   (the "License"); you may not use this file except in compliance with the

--- a/frontend/src/main/resources/org/onehippo/forge/folderctxmenus/cms/plugin/CopyOrMoveFolderDialog.html
+++ b/frontend/src/main/resources/org/onehippo/forge/folderctxmenus/cms/plugin/CopyOrMoveFolderDialog.html
@@ -1,5 +1,5 @@
 <!--
-  Copyright 2024-2025 Bloomreach (https://www.bloomreach.com)
+  Copyright 2026 Bloomreach (https://www.bloomreach.com)
 
   Licensed under the Apache License, Version 2.0
   (the "License"); you may not use this file except in compliance with the

--- a/frontend/src/test/java/org/onehippo/forge/folderctxmenus/cms/plugin/FolderActionDocumentArgumentsTest.java
+++ b/frontend/src/test/java/org/onehippo/forge/folderctxmenus/cms/plugin/FolderActionDocumentArgumentsTest.java
@@ -20,9 +20,9 @@ import java.io.ByteArrayOutputStream;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class FolderActionDocumentArgumentsTest {
 

--- a/frontend/src/test/java/org/onehippo/forge/folderctxmenus/cms/plugin/FolderActionDocumentArgumentsTest.java
+++ b/frontend/src/test/java/org/onehippo/forge/folderctxmenus/cms/plugin/FolderActionDocumentArgumentsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Bloomreach (https://www.bloomreach.com)
+ * Copyright 2026 Bloomreach (https://www.bloomreach.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/frontend/src/test/java/org/onehippo/forge/folderctxmenus/cms/plugin/PermissionCheckTest.java
+++ b/frontend/src/test/java/org/onehippo/forge/folderctxmenus/cms/plugin/PermissionCheckTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Bloomreach (https://www.bloomreach.com)
+ * Copyright 2026 Bloomreach (https://www.bloomreach.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/frontend/src/test/java/org/onehippo/forge/folderctxmenus/cms/plugin/ProgressCompletionSummaryTest.java
+++ b/frontend/src/test/java/org/onehippo/forge/folderctxmenus/cms/plugin/ProgressCompletionSummaryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Bloomreach (https://www.bloomreach.com)
+ * Copyright 2026 Bloomreach (https://www.bloomreach.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/frontend/src/test/java/org/onehippo/forge/folderctxmenus/cms/plugin/ProgressCompletionSummaryTest.java
+++ b/frontend/src/test/java/org/onehippo/forge/folderctxmenus/cms/plugin/ProgressCompletionSummaryTest.java
@@ -21,9 +21,9 @@ import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 import java.io.Serializable;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class ProgressCompletionSummaryTest {
 

--- a/frontend/src/test/java/org/onehippo/forge/folderctxmenus/cms/plugin/ProgressPanelJsonTest.java
+++ b/frontend/src/test/java/org/onehippo/forge/folderctxmenus/cms/plugin/ProgressPanelJsonTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Bloomreach (https://www.bloomreach.com)
+ * Copyright 2026 Bloomreach (https://www.bloomreach.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/frontend/src/test/java/org/onehippo/forge/folderctxmenus/cms/plugin/ProgressPanelJsonTest.java
+++ b/frontend/src/test/java/org/onehippo/forge/folderctxmenus/cms/plugin/ProgressPanelJsonTest.java
@@ -17,17 +17,17 @@ package org.onehippo.forge.folderctxmenus.cms.plugin;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class ProgressPanelJsonTest {
 
     private static final ObjectMapper MAPPER = new ObjectMapper();
     private ProgressTrackingOperationProgress progress;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         progress = new ProgressTrackingOperationProgress();
     }
@@ -136,7 +136,7 @@ public class ProgressPanelJsonTest {
         assertEquals(42, node.get("finalizingCount").asLong());
         // summary must ALSO be present alongside finalizing so the JS
         // summary-first check can stop polling after completion
-        assertTrue("summary must be present even while finalizing", node.has("summary"));
+        assertTrue(node.has("summary"), "summary must be present even while finalizing");
         assertEquals("Successfully copied 42 items", node.get("summary").get("message").asText());
         assertFalse(node.get("summary").get("error").asBoolean());
         assertTrue(node.get("completed").asBoolean());

--- a/frontend/src/test/java/org/onehippo/forge/folderctxmenus/cms/plugin/ProgressTrackingOperationProgressTest.java
+++ b/frontend/src/test/java/org/onehippo/forge/folderctxmenus/cms/plugin/ProgressTrackingOperationProgressTest.java
@@ -15,16 +15,16 @@
  */
 package org.onehippo.forge.folderctxmenus.cms.plugin;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class ProgressTrackingOperationProgressTest {
 
     private ProgressTrackingOperationProgress progress;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         progress = new ProgressTrackingOperationProgress();
     }
@@ -214,7 +214,7 @@ public class ProgressTrackingOperationProgressTest {
         String eta = progress.getEstimatedTimeRemaining();
         // ETA should be non-empty and contain "remaining"
         if (!eta.isEmpty()) {
-            assertTrue("ETA should contain 'remaining': " + eta, eta.contains("remaining"));
+            assertTrue(eta.contains("remaining"), "ETA should contain 'remaining': " + eta);
         }
     }
 

--- a/frontend/src/test/java/org/onehippo/forge/folderctxmenus/cms/plugin/ProgressTrackingOperationProgressTest.java
+++ b/frontend/src/test/java/org/onehippo/forge/folderctxmenus/cms/plugin/ProgressTrackingOperationProgressTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Bloomreach (https://www.bloomreach.com)
+ * Copyright 2026 Bloomreach (https://www.bloomreach.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pom.xml
+++ b/pom.xml
@@ -17,14 +17,14 @@
     <parent>
         <groupId>org.onehippo.cms7</groupId>
         <artifactId>hippo-cms7-project</artifactId>
-        <version>16.6.5</version>
+        <version>17.0.0</version>
     </parent>
 
     <name>Bloomreach XM Extra Folder Context Menus</name>
     <description>Bloomreach XM Extra Folder Context Menus</description>
     <groupId>org.onehippo.forge.folderctxmenus</groupId>
     <artifactId>folderctxmenus</artifactId>
-    <version>7.2.0-SNAPSHOT</version>
+    <version>8.0.0-SNAPSHOT</version>
     <packaging>pom</packaging>
     <url>https://bloomreach-forge.github.io/folder-context-menus</url>
 
@@ -63,7 +63,7 @@
 
     <issueManagement>
         <system>Jira</system>
-        <url>https://issues.onehippo.com/browse/FORGE</url>
+        <url>https://bloomreach.atlassian.net/browse/FORGE</url>
     </issueManagement>
 
     <distributionManagement>
@@ -140,13 +140,6 @@
                 <version>${hippo.release.version}</version>
             </dependency>
 
-            <dependency>
-                <groupId>org.junit.vintage</groupId>
-                <artifactId>junit-vintage-engine</artifactId>
-                <version>${junit-jupiter.version}</version>
-                <scope>test</scope>
-            </dependency>
-
         </dependencies>
 
     </dependencyManagement>
@@ -157,7 +150,7 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>
-                    <!-- Preserve parent add-opens flags for Java 17 and append JaCoCo agent via @{argLine} -->
+                    <!-- Preserve parent add-opens flags for Java 21 and append JaCoCo agent via @{argLine} -->
                     <argLine>-Xmx1024m
                         --add-opens java.base/java.io=ALL-UNNAMED
                         --add-opens java.base/java.lang=ALL-UNNAMED

--- a/pom.xml
+++ b/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  Copyright 2024 Bloomreach (https://www.bloomreach.com)
+  Copyright 2026 Bloomreach (https://www.bloomreach.com)
 
   Licensed under the Apache License, Version 2.0
   (the "License"); you may not use this file except in compliance with the
@@ -29,8 +29,8 @@
     <url>https://bloomreach-forge.github.io/folder-context-menus</url>
 
     <properties>
-        <plugin.jxr.version>3.3.0</plugin.jxr.version>
-        <brut.version>5.0.1</brut.version>
+        <plugin.jxr.version>3.6.0</plugin.jxr.version>
+        <brut.version>6.1.0</brut.version>
     </properties>
 
     <licenses>

--- a/repository/pom.xml
+++ b/repository/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  Copyright 2024 Bloomreach (https://www.bloomreach.com)
+  Copyright 2026 Bloomreach (https://www.bloomreach.com)
 
   Licensed under the Apache License, Version 2.0
   (the "License"); you may not use this file except in compliance with the

--- a/repository/pom.xml
+++ b/repository/pom.xml
@@ -16,7 +16,7 @@
   <parent>
     <groupId>org.onehippo.forge.folderctxmenus</groupId>
     <artifactId>folderctxmenus</artifactId>
-    <version>7.2.0-SNAPSHOT</version>
+    <version>8.0.0-SNAPSHOT</version>
   </parent>
 
   <name>Bloomreach XM Extra Folder Context Menus Repository</name>

--- a/src/site/site.xml
+++ b/src/site/site.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright 2024 Bloomreach (https://www.bloomreach.com)
+    Copyright 2026 Bloomreach (https://www.bloomreach.com)
 
     Licensed under the Apache License, Version 2.0 (the  "License");
     you may not use this file except in compliance with the License.
@@ -19,7 +19,7 @@
   <skin>
     <groupId>org.bloomreach.forge.mavenskin</groupId>
     <artifactId>forge-maven-skin</artifactId>
-    <version>3.2.1</version>
+    <version>3.2.2</version>
   </skin>
 
   <custom>

--- a/src/site/xdoc/index.xml
+++ b/src/site/xdoc/index.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright 2024 Bloomreach (https://www.bloomreach.com)
+    Copyright 2026 Bloomreach (https://www.bloomreach.com)
 
     Licensed under the Apache License, Version 2.0 (the  "License");
     you may not use this file except in compliance with the License.

--- a/src/site/xdoc/install.xml
+++ b/src/site/xdoc/install.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright 2025 Bloomreach (https://www.bloomreach.com)
+    Copyright 2026 Bloomreach (https://www.bloomreach.com)
 
     Licensed under the Apache License, Version 2.0 (the  "License");
     you may not use this file except in compliance with the License.

--- a/src/site/xdoc/release-notes.xml
+++ b/src/site/xdoc/release-notes.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-    Copyright 2025 Bloomreach (https://www.bloomreach.com)
+    Copyright 2026 Bloomreach (https://www.bloomreach.com)
 
     Licensed to the Apache Software Foundation (ASF) under one or more
     contributor license agreements.  See the NOTICE file distributed with
@@ -28,6 +28,10 @@
         <tr>
           <th>Plugin version</th>
           <th>Bloomreach Experience Manager version</th>
+        </tr>
+        <tr>
+          <td>8.x</td>
+          <td>17.x</td>
         </tr>
         <tr>
           <td>7.x</td>


### PR DESCRIPTION
Bump parent POMs from hippo-cms7-project/release 16.6.5 to 17.0.0 and project artifact version from 7.x to 8.0.0-SNAPSHOT across all 16 modules.

Migrate frontend tests from JUnit 4 to JUnit 5 Jupiter; junit:junit was dropped from the v17 BOM and DocumentListFilter moved from cms-perspectives to cms-api with a simplified filter(NodeIterator) signature — removed the now-invalid filter(Node, NodeIterator) override accordingly.

Also updates issueManagement URL to bloomreach.atlassian.net and drops the unused junit-vintage-engine from root dependencyManagement.

(co-authored with Claude Code)